### PR TITLE
Map null for nullable object with empty array data

### DIFF
--- a/src/MapperConfig.php
+++ b/src/MapperConfig.php
@@ -42,6 +42,11 @@ class MapperConfig
     public bool $enumTryFrom = false;
 
     /**
+     * If true, an empty array will be mapped as null to a nullable object type.
+     */
+    public bool $nullObjectFromEmptyArray = false;
+
+    /**
      * If true, mapping a null value to a non-nullable field will throw an UnexpectedNullValueException.
      */
     public bool $strictNullMapping = true;

--- a/src/Objects/ObjectMapper.php
+++ b/src/Objects/ObjectMapper.php
@@ -95,9 +95,9 @@ class ObjectMapper
         $content = '';
 
         if ($isNullable && $this->mapper->config->nullObjectFromEmptyArray) {
-            $content .= 'if (\$data === []) {' . \PHP_EOL;
-            $content .= $tab . 'return null;' . \PHP_EOL;
-            $content .= '}' . \PHP_EOL . \PHP_EOL;
+            $content .= $tab . $tab . 'if ($data === []) {' . \PHP_EOL;
+            $content .= $tab . $tab . $tab . 'return null;' . \PHP_EOL;
+            $content .= $tab . $tab . '}' . \PHP_EOL . \PHP_EOL;
         }
 
         // Instantiate a new object
@@ -115,7 +115,7 @@ class ObjectMapper
 
             $args[] = $arg;
         }
-        $content .= '$x = new ' . $blueprint->namespacedClassName . '(' . \implode(', ', $args) . ');';
+        $content .= $tab . $tab . '$x = new ' . $blueprint->namespacedClassName . '(' . \implode(', ', $args) . ');';
 
         // Map properties
         foreach ($blueprint->properties as $name => $property) {
@@ -159,7 +159,7 @@ class ObjectMapper
         if (! \\function_exists('{$mapFunctionName}')) {
             function {$mapFunctionName}({$mapperClass} \$mapper, array \$data)
             {
-                {$content}
+        {$content}
 
                 return \$x;
             }

--- a/tests/MapperTest.php
+++ b/tests/MapperTest.php
@@ -31,15 +31,12 @@ final class MapperTest extends TestCase
     {
         $options = new MapperConfig();
         $options->nullObjectFromEmptyArray = true;
-        $options->debug = true;
-
         $mapper = new Mapper($options);
 
         // Return null for nullable object
         $this->assertNull($mapper->map('?' . Nullable::class, []));
 
         // Don't return null if not nullable
-        $mapper->clearCache();
         $this->assertInstanceOf(Nullable::class, $mapper->map(Nullable::class, []));
     }
 

--- a/tests/MapperTest.php
+++ b/tests/MapperTest.php
@@ -8,6 +8,7 @@ use Jerodev\DataMapper\Mapper;
 use Jerodev\DataMapper\MapperConfig;
 use Jerodev\DataMapper\Tests\_Mocks\Aliases;
 use Jerodev\DataMapper\Tests\_Mocks\Constructor;
+use Jerodev\DataMapper\Tests\_Mocks\Nullable;
 use Jerodev\DataMapper\Tests\_Mocks\SelfMapped;
 use Jerodev\DataMapper\Tests\_Mocks\SuitEnum;
 use Jerodev\DataMapper\Tests\_Mocks\SuperUserDto;
@@ -24,6 +25,24 @@ final class MapperTest extends TestCase
     {
         $this->assertSame($expectation, (new Mapper())->map($type, $value));
     }
+
+    /** @test */
+    public function it_should_map_nullable_objects_from_empty_array(): void
+    {
+        $options = new MapperConfig();
+        $options->nullObjectFromEmptyArray = true;
+        $options->debug = true;
+
+        $mapper = new Mapper($options);
+
+        // Return null for nullable object
+        $this->assertNull($mapper->map('?' . Nullable::class, []));
+
+        // Don't return null if not nullable
+        $mapper->clearCache();
+        $this->assertInstanceOf(Nullable::class, $mapper->map(Nullable::class, []));
+    }
+
     /**
      * @test
      * @dataProvider objectValuesDataProvider

--- a/tests/_Mocks/Nullable.php
+++ b/tests/_Mocks/Nullable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jerodev\DataMapper\Tests\_Mocks;
+
+class Nullable
+{
+    public ?string $name;
+
+    public function __construct(
+        public ?int $id,
+    ) {
+    }
+}


### PR DESCRIPTION
Add an option to allow mapping an empty array to `null` for nullable objects.