### PR TITLE
Array field mapping in property doc blocks

### DIFF
--- a/src/Objects/DocBlockParser.php
+++ b/src/Objects/DocBlockParser.php
@@ -54,14 +54,14 @@ class DocBlockParser
                 continue;
             }
 
-            if (\in_array($char, ['|', ','])) {
+            if (\in_array($char, ['|', ',', ':'])) {
                 $type .= $char;
                 $lastChar = $char;
                 $sawSpace = false;
                 continue;
             }
 
-            if ($sawSpace && ! \in_array($lastChar, ['|', ','])) {
+            if ($sawSpace && ! \in_array($lastChar, ['|', ',', ':'])) {
                 break;
             }
 

--- a/tests/MapperTest.php
+++ b/tests/MapperTest.php
@@ -7,6 +7,7 @@ use Jerodev\DataMapper\Exceptions\UnexpectedNullValueException;
 use Jerodev\DataMapper\Mapper;
 use Jerodev\DataMapper\MapperConfig;
 use Jerodev\DataMapper\Tests\_Mocks\Aliases;
+use Jerodev\DataMapper\Tests\_Mocks\ArrayProperties;
 use Jerodev\DataMapper\Tests\_Mocks\Constructor;
 use Jerodev\DataMapper\Tests\_Mocks\Nullable;
 use Jerodev\DataMapper\Tests\_Mocks\SelfMapped;
@@ -207,6 +208,21 @@ final class MapperTest extends TestCase
                 'name' => 'Joe',
                 'score' => null,
             ],
+            $dto,
+        ];
+
+        // Special array cases
+        $dto = new ArrayProperties();
+        $dto->ints = [2, 5, 8];
+        $dto->fieldsWithKeys = [
+            3 => [
+                'foo' => 'bar',
+                'bar' => 8,
+            ],
+        ];
+        yield [
+            ArrayProperties::class,
+            (array)$dto,
             $dto,
         ];
     }

--- a/tests/_Mocks/ArrayProperties.php
+++ b/tests/_Mocks/ArrayProperties.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jerodev\DataMapper\Tests\_Mocks;
+
+class ArrayProperties
+{
+    /** @var array<int> */
+    public array $ints;
+
+    /** @var array<int, array{foo: string, bar: int}> */
+    public array $fieldsWithKeys;
+}


### PR DESCRIPTION
There was an issue where property doc blocks did not allow a space after `:` in array field definitions.

For example:
```php
/** @var array{Foo: string} */
public array $a;
```